### PR TITLE
feat #78 - map API 클라이언트ID 엔드포인트 컨트롤러로 이동

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,11 +19,6 @@ async function bootstrap() {
   // 정적 파일 제공 (public 폴더)
   app.use('/test', express.static(path.join(__dirname, '..', 'public'))) // 루트까지(..) 이동한 뒤, public을 찾는다.
 
-  // /api/client-id 요청 시 CLIENT_ID 값을 JSON 형태로 반환하도록 추가
-  app.getHttpAdapter().get('/api/client-id', (req, res) => {
-    res.json({ clientId: process.env.MAP_CLIENT_ID })
-  })
-
   await app.listen(process.env.PORT ?? 3000)
 }
 bootstrap()

--- a/src/maps/maps.controller.ts
+++ b/src/maps/maps.controller.ts
@@ -5,6 +5,12 @@ import { MapsService } from './maps.service'
 export class MapsController {
     constructor(private readonly mapsService: MapsService) {}
 
+    // 클라이언트 ID
+    @Get('/client-id')
+    getClientId() {
+        return this.mapsService.getClientId()
+    }
+
     // 장소 검색
     @Get('/search')
     async searchPlaces(@Query('query') query: string) {

--- a/src/maps/maps.service.ts
+++ b/src/maps/maps.service.ts
@@ -12,12 +12,16 @@ export class MapsService {
 
     constructor(private readonly httpService: HttpService) {}
 
+    // 클라이언트 ID 반환
+    getClientId() {
+        return { clientId: this.MAP_CLIENT_ID }
+    }
+
     // 장소 검색
     async searchPlaces(query: string) {
         if (!query) {
             throw new BadRequestException('검색어를 입력하세요.')
         }
-
 
         const url = `https://openapi.naver.com/v1/search/local.json?query=${encodeURIComponent(query)}&display=5&start=1&sort=random`
         const headers = {


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #78 
<br/>


## 작업 내용
- 기존 main.ts에서 직접 처리하던 /api/client-id 엔드포인트를 maps.controller.ts 및 maps.service.ts로 이동
- API 호출 방식이 변경됨에 따라 기존 요청 경로 수정


## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- http://localhost:3000/api/maps/client-id 호출 시 응답이 정상적으로 반환되는지 확인
- 프론트에서 /api/maps/client-id 호출 시 문제없이 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인
- main.ts에서 /api/client-id가 제거되었는지 확인
- 기존 /api/client-id를 사용하던 부분을 /api/maps/client-id로 변경했는지 확인


## 기타 사항
- 프론트엔드에서 /api/maps/client-id 엔드포인트를 사용하도록 경로 변경
- API 호출 테스트 결과 정상적으로 clientId 값이 반환됨
