### PR TITLE
feat: 현위치 기반 가게 검색 기능 추가 및 검색 범위 확장

### DIFF
--- a/src/maps/maps.controller.ts
+++ b/src/maps/maps.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common'
+import { BadRequestException, Controller, Get, Param, Query } from '@nestjs/common'
 import { MapsService } from './maps.service'
 
 @Controller('api/maps')
@@ -12,22 +12,32 @@ export class MapsController {
     }
 
     // 장소 검색
-    @Get('/search')
-    async searchPlaces(@Query('query') query: string) {
-        return this.mapsService.searchPlaces(query)
+    @Get('/:lat/:lng/:query')
+    async readStoreByName(
+        @Param('lat') lat: string,  
+        @Param('lng') lng: string,
+        @Param('query') query: string
+    ) {
+        if (!query) {
+            throw new BadRequestException('검색어를 입력하세요.')
+        }
+        if (!lat || !lng) {
+            throw new BadRequestException('위도와 경도를 입력하세요.')
+        }
+
+        return this.mapsService.getStoreByName(parseFloat(lat), parseFloat(lng), query)
     }
 
-    // 주변 장소 검색
-    @Get('/nearby')
-    async getNearbyPlaces(
-        @Query('lat') lat: string, // 위도
-        @Query('lng') lng: string  // 경도
-      ) {
-            if (!lat || !lng) {
-                return { message: '위도와 경도를 입력하세요.' }
-            }
-        
-            const places = await this.mapsService.getNearbyPlaces(parseFloat(lat), parseFloat(lng))
-            return places
+    // 주변 음식점 조회
+    @Get('/:lat/:lng')
+    async readNearbyStores(
+        @Param('lat') lat: string, 
+        @Param('lng') lng: string  
+    ) {
+        if (!lat || !lng) {
+            throw new BadRequestException('위도와 경도를 입력하세요.')
         }
+
+        return await this.mapsService.getNearbyStores(parseFloat(lat), parseFloat(lng))
+    }
 }

--- a/src/maps/maps.service.ts
+++ b/src/maps/maps.service.ts
@@ -17,38 +17,81 @@ export class MapsService {
         return { clientId: this.MAP_CLIENT_ID }
     }
 
-    // 장소 검색
-    async searchPlaces(query: string) {
+    // 현위치 기준 음식점 조회
+    async getStoreByName(lat: number, lng: number, query: string) {
         if (!query) {
             throw new BadRequestException('검색어를 입력하세요.')
         }
-
-        const url = `https://openapi.naver.com/v1/search/local.json?query=${encodeURIComponent(query)}&display=5&start=1&sort=random`
-        const headers = {
-            'X-Naver-Client-Id': this.MAP_SERVICE_ID,
-            'X-Naver-Client-Secret': this.MAP_SERVICE_SECRET
-            // 'Content-Type': 'application/json'
+        if (!lat || !lng) {
+            throw new BadRequestException('위치 정보가 필요합니다.')
         }
-
+    
         try {
-            const response = await firstValueFrom(this.httpService.get(url, { headers }))
+            // 현재 좌표를 기반으로 주소 얻기
+            const reverseResponse = await axios.get('https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc', {
+                headers: {
+                    'X-NCP-APIGW-API-KEY-ID': this.MAP_CLIENT_ID,
+                    'X-NCP-APIGW-API-KEY': this.MAP_CLIENT_SECRET,
+                },
+                params: {
+                    coords: `${lng},${lat}`,
+                    orders: 'addr', // 주소 정보 반환
+                    output: 'json', // JSON 형식 응답
+                },
+            })
+    
+            const region = reverseResponse.data.results[0].region
+    
+            // 지역 정보를 우선순위에 따라 배열로 정리
+            const regionNames = [region.area4?.name, region.area3?.name, region.area2?.name, region.area1?.name].filter(Boolean)
 
-            if (!response.data.items || response.data.items.length === 0) {
-                throw new NotFoundException('검색 결과가 없습니다.')
+            let searchResults: any[] = []
+
+            // 검색을 단계적으로 수행하여 최대 5개 결과까지 채우기
+            for (const regionName of regionNames) {
+                if (searchResults.length >= 5) break // 최대 5개 결과만 반환
+
+                const placesResponse = await axios.get('https://openapi.naver.com/v1/search/local.json', {
+                    headers: {
+                        'X-Naver-Client-Id': this.MAP_SERVICE_ID,
+                        'X-Naver-Client-Secret': this.MAP_SERVICE_SECRET,
+                    },
+                    params: {
+                        query: `${query} ${regionName}`,
+                        display: 5, // 최대 5개씩 가져오기
+                        start: 1,
+                        sort: 'random', // 검색 결과 정렬 방식
+                        radius: 1000, // 반경 1km 내에서 검색
+                    },
+                })
+
+                // 현재 검색 결과를 추가하면서 중복 방지
+                const newResults = placesResponse.data.items.map((item: any) => ({
+                    store_name: item.title.replace(/<[^>]+>/g, ''), // HTML 태그 제거
+                    address: item.address,
+                    lat: parseFloat(item.mapy),
+                    lng: parseFloat(item.mapx),
+                    category: item.category || '음식점',
+                    contact_number: item.telephone || '',
+                }))
+
+                // 기존 결과와 중복되지 않는 새 결과 추가
+                searchResults = [...new Set([...searchResults, ...newResults])].slice(0, 5)
             }
 
-            return response.data.items
+            return searchResults
         } catch (error) {
-            // HttpException이면 원래 응답을 그대로 전달
             if (error.response) {
-                throw new HttpException(error.response, error.status)
+                console.error('API 요청 실패:', error.response.status, error.response.data)
+            } else {
+                console.error('네트워크 오류 또는 API 요청 중 알 수 없는 오류 발생:', error)
             }
-
-            throw new InternalServerErrorException('외부 API 호출 중 오류가 발생했습니다.')
+            throw new Error('음식점 정보를 가져오는 데 실패했습니다.')
         }
     }
 
-    async getNearbyPlaces(lat: number, lng: number) {
+    // 주변 음식점 조회
+    async getNearbyStores(lat: number, lng: number) {
         try {
             // 현재 좌표를 기반으로 주소 얻기
             const reverseResponse = await axios.get('https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc', {


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #97 
<br/>


## 작업 내용
- 사용자 현위치를 기반으로 가게 검색할 수 있도록 API 수정
- 현재 위치(`lat`, `lng`)가 없을 경우 기본값(서울) 사용
- 지역 정보(`area4 → area3 → area2 → area1`)를 활용하여 검색 범위를 자동 확장
- 최대 5개의 검색 결과를 반환하도록 검색 로직 개선
- 중복된 검색 결과를 제거하고, API 응답 최적화

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
