### PR TITLE
[refactor] #132 - 인증 로직 정비 및 @Public() 분기 적용

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,9 @@ import { AuthModule } from './auth/auth.module'
 import { FavoriteModule } from './favorites/favorites.module'
 import { FileModule } from './file/file.module'
 import { EventsModule } from './events/events.module'
+import { APP_GUARD } from '@nestjs/core'
+import { JwtAuthGuard } from './common/custom-decorators/jwt-auth.guard'
+import { RolesGuard } from './common/custom-decorators/custom-role.guard'
 
 @Module({
   imports: [
@@ -30,5 +33,15 @@ import { EventsModule } from './events/events.module'
     FileModule,
     EventsModule,
   ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard, // 먼저 인증
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard, // 그 다음 권한
+    },
+  ]
 })
 export class AppModule { }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,12 +4,14 @@ import { CreateUserDTO } from 'src/users/DTO/create-user.dto'
 import { ApiResponseDTO } from 'src/common/api-reponse-dto/api-response.dto'
 import { SignInDTO } from './DTO/sign-in.dto'
 import { Response } from 'express'
+import { Public } from 'src/common/custom-decorators/public.decorator'
 
 @Controller('api/auth')
 export class AuthController {
     constructor(private authService: AuthService) { }
 
     // Sign-Up
+    @Public()
     @Post('/signup')
     async singUp(
         @Body() createUserDTO: CreateUserDTO
@@ -20,6 +22,7 @@ export class AuthController {
     }
 
     // Sign-In
+    @Public()
     @Post('/signin')
     async singIn(
         @Body() signInDTO: SignInDTO,

--- a/src/common/custom-decorators/custom-role.guard.ts
+++ b/src/common/custom-decorators/custom-role.guard.ts
@@ -3,12 +3,23 @@ import { Reflector } from "@nestjs/core";
 import { UserRole } from "src/users/entities/user-role.enum";
 import { User } from "src/users/entities/user.entity";
 import { ROLES_KEY } from "./roles.decorator";
+import { IS_PUBLIC_KEY } from "./public.decorator";
 
 @Injectable()
 export class RolesGuard implements CanActivate {
     constructor(private reflector: Reflector) { }
 
     canActivate(context: ExecutionContext): boolean {
+        // public으로 설정된 경우 인증/권한 검사 생략
+        const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ])
+
+        if (isPublic) {
+            return true
+        }
+
         // 핸들러 또는 클래스에 설정된 역할 가져오기
         const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
             context.getHandler(),

--- a/src/common/custom-decorators/jwt-auth.guard.ts
+++ b/src/common/custom-decorators/jwt-auth.guard.ts
@@ -1,0 +1,28 @@
+import { ExecutionContext, Injectable, Logger } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import { Reflector } from '@nestjs/core'
+import { IS_PUBLIC_KEY } from 'src/common/custom-decorators/public.decorator'
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  private readonly logger = new Logger(JwtAuthGuard.name)
+
+  constructor(private reflector: Reflector) {
+    super()
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ])
+
+    if (isPublic) {
+      this.logger.debug(`[Public Route]: ${context.getHandler().name}`)
+      return true
+    }
+
+    this.logger.debug(`[Protected Route]: ${context.getHandler().name}`)
+    return super.canActivate(context)
+  }
+}

--- a/src/common/custom-decorators/public.decorator.ts
+++ b/src/common/custom-decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -12,7 +12,7 @@ import { ReadEventDTO } from './DTO/read-event.dto'
 import { StoresService } from 'src/stores/stores.service'
 
 @Controller('api/stores/:store_id/events')
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+// @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class EventsController {
     constructor(
         private eventsService: EventsService,

--- a/src/manager-requests/manager-requests.controller.ts
+++ b/src/manager-requests/manager-requests.controller.ts
@@ -11,7 +11,7 @@ import { Roles } from 'src/common/custom-decorators/roles.decorator'
 import { AuthenticatedRequest } from 'src/auth/interfaces/authenticated-request.interface'
 
 @Controller('api/manager-requests')
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+// @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class ManagerRequestsController {
     constructor(private managerRequestsService: ManagerRequestsService) { }
 

--- a/src/maps/maps.controller.ts
+++ b/src/maps/maps.controller.ts
@@ -2,24 +2,23 @@ import { BadRequestException, Controller, Get, Param, Query, UseGuards } from '@
 import { MapsService } from './maps.service'
 import { RolesGuard } from 'src/common/custom-decorators/custom-role.guard'
 import { AuthGuard } from '@nestjs/passport'
-import { Roles } from 'src/common/custom-decorators/roles.decorator'
-import { UserRole } from 'src/users/entities/user-role.enum'
+import { Public } from 'src/common/custom-decorators/public.decorator'
 
 @Controller('api/maps')
-@UseGuards(AuthGuard('jwt'), RolesGuard) // JWT인증, roles guard 적용
+// @UseGuards(AuthGuard('jwt'), RolesGuard) // JWT인증, roles guard 적용
 export class MapsController {
     constructor(private readonly mapsService: MapsService) {}
 
     // 클라이언트 ID
+    @Public()
     @Get('/client-id')
-    @Roles(UserRole.USER, UserRole.ADMIN)
     getClientId() {
         return this.mapsService.getClientId()
     }
 
     // 현위치 기준 검색 목록 조회 (map api)
+    @Public()
     @Get('/:lat/:lng/:query')
-    @Roles(UserRole.USER, UserRole.ADMIN)
     async readStoreByName(
         @Param('lat') lat: string,  
         @Param('lng') lng: string,
@@ -36,6 +35,7 @@ export class MapsController {
     }
 
     // 현위치 기준 주변 가게 조회
+    @Public()
     @Get('/')
     async readStoreByCurrentLocation(
         @Query('lat') lat: string,

--- a/src/menus/menus.controller.ts
+++ b/src/menus/menus.controller.ts
@@ -14,7 +14,7 @@ import { UpdateMenuDTO } from './DTO/update-menu.dto'
 import { StoresService } from 'src/stores/stores.service'
 
 @Controller('api/stores/:store_id/menus')
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+// @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class MenusController {
     constructor(
         private menusService: MenusService,

--- a/src/replies/replies.controller.ts
+++ b/src/replies/replies.controller.ts
@@ -12,7 +12,7 @@ import { UserRole } from 'src/users/entities/user-role.enum'
 import { Roles } from 'src/common/custom-decorators/roles.decorator'
 
 @Controller('api/replies')
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+// @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class RepliesController {
     constructor(private repliesService: RepliesService) { }
 

--- a/src/reviews/reviews.controller.ts
+++ b/src/reviews/reviews.controller.ts
@@ -13,7 +13,7 @@ import { CreateReviewDTO } from './DTO/create-review.dto'
 import { FilesInterceptor } from '@nestjs/platform-express'
 
 @Controller('api/stores/:store_id/reviews')
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+// @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class ReviewsController {
     private readonly logger = new Logger(ReviewsController.name)
 

--- a/src/store-requests/store-requests.controller.ts
+++ b/src/store-requests/store-requests.controller.ts
@@ -11,7 +11,7 @@ import { Roles } from "src/common/custom-decorators/roles.decorator"
 import { AuthenticatedRequest } from "src/auth/interfaces/authenticated-request.interface"
 
 @Controller('api/store-requests')
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+// @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class StoreRequestsController {
     constructor(private storeRequestsService: StoreRequestsService) { }
 

--- a/src/stores/stores.controller.ts
+++ b/src/stores/stores.controller.ts
@@ -13,7 +13,7 @@ import { AuthenticatedRequest } from 'src/auth/interfaces/authenticated-request.
 import { Store } from './entities/store.entity'
 
 @Controller('api/stores')
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+// @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class StoresController {
     constructor(private storesService: StoresService) { }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -9,6 +9,7 @@ import { Roles } from 'src/common/custom-decorators/roles.decorator'
 import { UserRole } from './entities/user-role.enum'
 import { AuthGuard } from '@nestjs/passport'
 import { AuthenticatedRequest } from 'src/auth/interfaces/authenticated-request.interface'
+import { Public } from 'src/common/custom-decorators/public.decorator'
 
 @Controller('api/users')
 export class UsersController {
@@ -16,7 +17,7 @@ export class UsersController {
 
     // READ - 모든 유저 정보 조회
     @Get('/')
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    // @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(UserRole.ADMIN)
     async readAllUsers(): Promise<ApiResponseDTO<ReadUserDTO[]>> {
         const users: User[] = await this.usersService.readAllUsers()
@@ -26,6 +27,7 @@ export class UsersController {
     }
 
     // READ - 이메일 중복 검사
+    @Public()
     @Get('/check-email')
     async readEmailExists(
         @Query('email') email: string
@@ -36,7 +38,7 @@ export class UsersController {
 
     // READ - 내 정보 조회
     @Get('/my')
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    // @UseGuards(AuthGuard('jwt'), RolesGuard)
     async readUserById(
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDTO<ReadUserDTO>> {
@@ -51,7 +53,7 @@ export class UsersController {
 
     // UPDATE - by user_id
     @Put('/')
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    // @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(UserRole.USER, UserRole.MANAGER)
     async updateUserById(
         @Req() req: AuthenticatedRequest,
@@ -66,7 +68,7 @@ export class UsersController {
 
     // DELETE - 탈퇴
     @Delete('/')
-    @UseGuards(AuthGuard('jwt'), RolesGuard)
+    // @UseGuards(AuthGuard('jwt'), RolesGuard)
     @Roles(UserRole.USER, UserRole.MANAGER)
     async deleteUserById(
         @Req() req: AuthenticatedRequest


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #132 
<br/>


## 작업 내용
- JwtAuthGuard를 새로 정의하여 @Public() 데코레이터 인식 가능하도록 구현
- JwtAuthGuard 및 기존 RolesGuard를 전역 가드(APP_GUARD)로 등록
- 개별 라우트에 선언되던 @UseGuards(AuthGuard('jwt'), RolesGuard) 제거
- 로그인, 이메일 중복 체크, 지도 관련 API 등에 @Public() 데코레이터 적용
- 클라이언트 측 fetch 요청에서 토큰 없이 호출 가능하도록 수정 (script.js)
- 인증/인가 로직의 흐름에 따라 디버깅 로그 추가

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
