### PR TITLE
[fix] #138 - 가게 조회 return에 category_id 및 category_name 필드 추가

### DIFF
--- a/src/maps/maps.service.ts
+++ b/src/maps/maps.service.ts
@@ -119,26 +119,30 @@ export class MapsService {
                         WHEN longitude BETWEEN 100000000 AND 999999999 THEN longitude / 1000000
                         WHEN longitude BETWEEN 1000000000 AND 9999999999 THEN longitude / 10000000
                         ELSE NULL
-                        END AS lon
+                        END AS lon,
+                        category_id
                     FROM store
                     WHERE latitude IS NOT NULL AND longitude IS NOT NULL
                     )
                     SELECT 
-                    store_id,
-                    store_name,
-                    address,
-                    latitude,
-                    longitude,
-                    lat,
-                    lon,
+                    cs.store_id,
+                    cs.store_name,
+                    cs.address,
+                    cs.latitude,
+                    cs.longitude,
+                    cs.lat,
+                    cs.lon,
                     ROUND(
                         6371 * acos(
-                        cos(radians(?)) * cos(radians(lat)) *
-                        cos(radians(lon) - radians(?)) +
-                        sin(radians(?)) * sin(radians(lat))
+                        cos(radians(?)) * cos(radians(cs.lat)) *
+                        cos(radians(cs.lon) - radians(?)) +
+                        sin(radians(?)) * sin(radians(cs.lat))
                         ), 2
-                    ) AS distance_km
-                    FROM converted_store
+                    ) AS distance_km,
+                     cs.category_id,
+                    c.category_name
+                    FROM converted_store cs
+                    JOIN category c ON cs.category_id = c.category_id
                     HAVING distance_km < ?
                     ORDER BY distance_km ASC
                     LIMIT 10
@@ -153,6 +157,8 @@ export class MapsService {
             lat: parseFloat(store.lat),
             lng: parseFloat(store.lon),
             distance: Math.round(store.distance),
+            category_id: store.category_id,
+            category_name: store.category_name,
           }))
       
         } catch (err) {


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #138 
<br/>


## 작업 내용
- 해당 PR에서 변경된 내용을 간략히 설명
- store 데이터 조회 시 category_id, category_name을 함께 포함하도록 쿼리 수정
- stores.map() 리턴 구문에 category_id, category_name 필드를 추가하여 프론트에서 접근 가능하게 처리

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 참고 자료 (결과물 사진 등)
![image](https://github.com/user-attachments/assets/2df8d87c-7b3b-4f43-aa71-ade754b9b291)