### PR TITLE
[feat] #155 - 추천 키워드 기반 DB, 외부 가게 통합 검색 API 구현

### DIFF
--- a/src/maps/maps.controller.ts
+++ b/src/maps/maps.controller.ts
@@ -3,6 +3,7 @@ import { MapsService } from './maps.service'
 import { RolesGuard } from 'src/common/custom-decorators/custom-role.guard'
 import { AuthGuard } from '@nestjs/passport'
 import { Public } from 'src/common/custom-decorators/public.decorator'
+import { Store } from 'src/stores/entities/store.entity'
 
 @Controller('api/maps')
 // @UseGuards(AuthGuard('jwt'), RolesGuard) // JWT인증, roles guard 적용
@@ -61,4 +62,23 @@ export class MapsController {
 
     //     return await this.mapsService.getNearbyStores(parseFloat(lat), parseFloat(lng))
     // }
+
+    // 네이버 장소 검색 + DB 매칭
+    @Public()
+    @Get('naver-match')
+    async getMatchedStoresFromNaver(
+        @Query('keyword') keyword: string,
+        @Query('lat') lat: string,
+        @Query('lng') lng: string,
+    ) {
+        const latNum = parseFloat(lat);
+        const lngNum = parseFloat(lng);
+
+        if (!keyword || isNaN(latNum) || isNaN(lngNum)) {
+            throw new Error('keyword, lat, lng 모두 필요합니다.');
+        }
+
+        return await this.mapsService.findNearbyMatchedAndExternalStores(keyword, latNum, lngNum);
+    }
+
 }


### PR DESCRIPTION
<!-- 제목은 [태그] #이슈번호 - 작업내용 요약 형식으로 작성해주세요 -->
### Issue
closed #155 
<br/>


## 작업 내용
- 네이버 로컬 검색 API 호출 후 DB 가게와 유사도 기반 매칭
- 전화번호, 상호, 주소 일부 포함 기준으로 DB와 매칭
- matchedStores (DB 가게), externalPlaces (외부 장소)로 응답 분리
- GET /api/maps/naver-match?keyword=xxx&lat=xxx&lng=xxx API 추가

## 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인
- [x] 기존 코드에 영향을 주지 않는지 확인

## 기타 사항
- 리뷰어가 알면 좋을 추가적인 내용
- 참고 자료 (결과물 사진 등)
- 피드백 요청
